### PR TITLE
Lstm BMI ngen bug fixes

### DIFF
--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -584,7 +584,6 @@ class bmi_LSTM(Bmi):
             Values at indices.
         """
         #NJF This must copy into dest!!!
-        tmp = self.get_value_ptr(var_name)
         #Convert to np.array in case of singleton/non numpy type, then flatten
         data = np.array(self.get_value(var_name)).flatten()
         dest[:] = data[indices]

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -86,7 +86,7 @@ class bmi_LSTM(Bmi):
                                 'land_surface_radiation~incoming~shortwave__energy_flux':['shortwave_radiation','W m-2'],
                                 'atmosphere_air_water~vapor__relative_saturation':['specific_humidity','kg kg-1'],
                                 'land_surface_air__pressure':['pressure','Pa'],
-                                'land_surface_air__temperature':['temperature','C'],
+                                'land_surface_air__temperature':['temperature','degC'],
                                 'land_surface_wind__x_component_of_velocity':['wind_u','m s-1'],
                                 'land_surface_wind__y_component_of_velocity':['wind_v','m s-1'],
                                 #--------------   STATIC Attributes -----------------------------
@@ -505,12 +505,7 @@ class bmi_LSTM(Bmi):
         src : array_like
               Array of new values.
         """
-        try:
-            #FIXME figure out why temperature isn't converted correctly
-            #For now, this is required to change Kelvin to Celcius for 
-            #temperature input
-            if var_name == 'land_surface_air__temperature':
-                value[0] = value[0] - 273.15   
+        try: 
             #NJF From NGEN, `vlaue` is a singleton array
             setattr( self, var_name, value[0] )
         

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -78,7 +78,10 @@ class bmi_LSTM(Bmi):
                                 'land_surface_water__runoff_volume_flux':['streamflow_cms','m3 s-1'],
                                 'land_surface_water__runoff_depth':['streamflow_m','m'],
                                 #--------------   Dynamic inputs --------------------------------
-                                'atmosphere_water__time_integral_of_precipitation_mass_flux':['total_precipitation','kg m-2'],
+                                #NJF Let the model assume equivalence of `kg m-2` == `mm h-1` since we can't convert
+                                #mass flux automatically from the ngen framework
+                                #'atmosphere_water__time_integral_of_precipitation_mass_flux':['total_precipitation','kg m-2'],
+                                'atmosphere_water__time_integral_of_precipitation_mass_flux':['total_precipitation','mm h-1'],
                                 'land_surface_radiation~incoming~longwave__energy_flux':['longwave_radiation','W m-2'],
                                 'land_surface_radiation~incoming~shortwave__energy_flux':['shortwave_radiation','W m-2'],
                                 'atmosphere_air_water~vapor__relative_saturation':['specific_humidity','kg kg-1'],

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -75,8 +75,8 @@ class bmi_LSTM(Bmi):
     #------------------------------------------------------
     #_var_name_map_long_first = {
     _var_name_units_map = {
-                                'land_surface_water__runoff_volume_flux':['streamflow_cfs','ft3 s-1'],
-                                'land_surface_water__runoff_depth':['streamflow_mm','mm'],
+                                'land_surface_water__runoff_volume_flux':['streamflow_cms','m3 s-1'],
+                                'land_surface_water__runoff_depth':['streamflow_m','m'],
                                 #--------------   Dynamic inputs --------------------------------
                                 'atmosphere_water__time_integral_of_precipitation_mass_flux':['total_precipitation','kg m-2'],
                                 'land_surface_radiation~incoming~longwave__energy_flux':['longwave_radiation','W m-2'],
@@ -296,12 +296,12 @@ class bmi_LSTM(Bmi):
         elif self.cfg_train['target_variables'][0] == 'QObs(mm/d)':
             self.surface_runoff_mm = (self.lstm_output[0,0,0].numpy().tolist() * self.out_std + self.out_mean) * (1/24)
             
-        self._values['land_surface_water__runoff_depth'] = self.surface_runoff_mm
-        setattr(self, 'land_surface_water__runoff_depth', self.surface_runoff_mm)
+        self._values['land_surface_water__runoff_depth'] = self.surface_runoff_mm/1000.0
+        setattr(self, 'land_surface_water__runoff_depth', self.surface_runoff_mm/1000.0)
         self.streamflow_cms = self.surface_runoff_mm * self.output_factor_cms
 
-        self._values['land_surface_water__runoff_volume_flux'] = self.streamflow_cms * (1/35.314)
-        setattr(self, 'land_surface_water__runoff_volume_flux', self.streamflow_cms * (1/35.314))
+        self._values['land_surface_water__runoff_volume_flux'] = self.streamflow_cms
+        setattr(self, 'land_surface_water__runoff_volume_flux', self.streamflow_cms)
 
     #-------------------------------------------------------------------
     def read_initial_states(self):

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -571,7 +571,7 @@ class bmi_LSTM(Bmi):
             return self.get_var_itemsize(var_name)*len(self.get_value_ptr(var_name))
         except TypeError:
             #must be scalar
-            return self.get_var_itemsize(var_name))
+            return self.get_var_itemsize(var_name)
     #------------------------------------------------------------ 
     def get_value_at_indices(self, var_name, dest, indices):
         """Get values at particular indices.

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -83,7 +83,7 @@ class bmi_LSTM(Bmi):
                                 'land_surface_radiation~incoming~shortwave__energy_flux':['shortwave_radiation','W m-2'],
                                 'atmosphere_air_water~vapor__relative_saturation':['specific_humidity','kg kg-1'],
                                 'land_surface_air__pressure':['pressure','Pa'],
-                                'land_surface_air__temperature':['temperature','K'],
+                                'land_surface_air__temperature':['temperature','C'],
                                 'land_surface_wind__x_component_of_velocity':['wind_u','m s-1'],
                                 'land_surface_wind__y_component_of_velocity':['wind_v','m s-1'],
                                 #--------------   STATIC Attributes -----------------------------
@@ -503,6 +503,11 @@ class bmi_LSTM(Bmi):
               Array of new values.
         """
         try:
+            #FIXME figure out why temperature isn't converted correctly
+            #For now, this is required to change Kelvin to Celcius for 
+            #temperature input
+            if var_name == 'land_surface_air__temperature':
+                value[0] = value[0] - 273.15   
             #NJF From NGEN, `vlaue` is a singleton array
             setattr( self, var_name, value[0] )
         
@@ -580,13 +585,13 @@ class bmi_LSTM(Bmi):
         array_like
             Values at indices.
         """
-        #JMFrame: chances are that the index will be zero, so let's include that logic
-        if np.array(self.get_value(var_name)).flatten().shape[0] == 1:
-            return self.get_value(var_name)
-        else:
-            val_array = self.get_value(var_name).flatten()
-            return np.array([val_array[i] for i in indices])
-
+        #NJF This must copy into dest!!!
+        tmp = self.get_value_ptr(var_name)
+        #Convert to np.array in case of singleton/non numpy type, then flatten
+        data = np.array(self.get_value(var_name)).flatten()
+        dest[:] = data[indices]
+        return dest
+ 
     # JG Note: remaining grid funcs do not apply for type 'scalar'
     #   Yet all functions in the BMI must be implemented 
     #   See https://bmi.readthedocs.io/en/latest/bmi.best_practices.html          


### PR DESCRIPTION
Some fixes to BMI implementation an some unit adjustments to get integration with NGen framework working.

## Changes

- Change output units to `m^3/s` and `m`
- Change input unit to `mm/hr` for assumption that the mass flux is indeed that, and this lets ngen properly convert `mm/s` forcing to `mm/hr`
- Fix `get_value_at_indicies` to ensure it copys data into the numpy array so ngen can read it

## Testing

1. Ran integration with NGen with reasonable output results.

## Todos

- Figure out why converting units of temperature to 'C' didn't trigger automatic conversion from the framework @mattw-nws @robertbartel 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

- [x] Linux
- [x] MacOs