### PR TITLE
typo and try_except fix

### DIFF
--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -510,7 +510,7 @@ class bmi_LSTM(Bmi):
             # I guess we should stick with the attribute names instead of a dictionary approach. 
             self._values[var_name] = value[0]
         # JLG 03242022: this isn't really an "error" block as standalone considers value as scalar?
-        except:
+        except TypeError:
             setattr( self, var_name, value )
         
             # jmframe: this next line is basically a duplicate. 

--- a/bmi_lstm.py
+++ b/bmi_lstm.py
@@ -509,7 +509,8 @@ class bmi_LSTM(Bmi):
             # jmframe: this next line is basically a duplicate. 
             # I guess we should stick with the attribute names instead of a dictionary approach. 
             self._values[var_name] = value[0]
-        except TypeError:
+        # JLG 03242022: this isn't really an "error" block as standalone considers value as scalar?
+        except:
             setattr( self, var_name, value )
         
             # jmframe: this next line is basically a duplicate. 
@@ -563,7 +564,7 @@ class bmi_LSTM(Bmi):
             return self.get_var_itemsize(var_name)*len(self.get_value_ptr(var_name))
         except TypeError:
             #must be scalar
-            return self.get_var_itemsize(var_name))
+            return self.get_var_itemsize(var_name)
     #------------------------------------------------------------ 
     def get_value_at_indices(self, var_name, dest, indices):
         """Get values at particular indices.

--- a/run-lstm-with-bmi.py
+++ b/run-lstm-with-bmi.py
@@ -25,8 +25,8 @@ print('Now loop through the inputs, set the forcing values, and update the model
 for precip, temp in zip(list(sample_data['total_precipitation'][3].data),
                         list(sample_data['temperature'][3].data)):
 
-    model.set_value('atmosphere_water__time_integral_of_precipitation_mass_flux',precip)
-    model.set_value('land_surface_air__temperature',temp)
+    model.set_value('atmosphere_water__time_integral_of_precipitation_mass_flux',np.atleast_1d(precip))
+    model.set_value('land_surface_air__temperature',np.atleast_1d(temp))
 
     print('the temperature and precipitation are set to {:.2f} and {:.2f}'.format(model.get_value('land_surface_air__temperature'), 
                                                      model.get_value('atmosphere_water__time_integral_of_precipitation_mass_flux')))


### PR DESCRIPTION
Fixes for `get_var_nbytes()` & `set_value()` required for standalone runs

## Changes

- `get_var_nbytes()`: remove lingering `)` in return line
- `set_value()`: the `else` block is expected for standalone versions as value passed is of type `scalar`

## Testing

1. run_bmi_unit_test.py
2. run-lstm-with-bmi.py


## Todos

- Test in `ngen`


