### PR TITLE
Update bmi def `get_var_type`

### DIFF
--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -709,7 +709,10 @@ class bmi_LSTM(Bmi):
             Data type.
         """
         #NJF Need an actual type here...
-        return type(self.get_value_ptr(long_var_name)).__name__ #.dtype
+        #return type(self.get_value_ptr(long_var_name)).__name__ #.dtype
+
+        #JG MW 03.01.23 - otherwise Bmi_py_Adaptor.hpp `get_analogous_cxx_type` fails
+        return self.get_value_ptr(long_var_name).dtype.name
     #------------------------------------------------------------ 
     def get_var_grid(self, name):
         
@@ -721,7 +724,10 @@ class bmi_LSTM(Bmi):
     def get_var_itemsize(self, name):
 #        return np.dtype(self.get_var_type(name)).itemsize
         # SDP. get_value() -> get_value_ptr()
-        return np.array(self.get_value_ptr(name)).itemsize
+        
+        # JG get_value_ptr is already an np.array
+        # return np.array(self.get_value_ptr(name)).itemsize
+        return self.get_value_ptr(name).itemsize  
 
     #------------------------------------------------------------ 
     def get_var_location(self, name):
@@ -885,11 +891,12 @@ class bmi_LSTM(Bmi):
         #return sys.getsizeof(self.get_value_ptr(var_name))
         #This is just the itemsize (size per element) * number of elements
         #Since all are currently scalar, this is 1
-        try:
-            return self.get_var_itemsize(var_name)*len(self.get_value_ptr(var_name))
-        except TypeError:
-            #must be scalar
-            return self.get_var_itemsize(var_name)
+        #try:
+        #    return self.get_var_itemsize(var_name)*len(self.get_value_ptr(var_name))
+        #except TypeError:
+        #    #must be scalar
+        #    return self.get_var_itemsize(var_name)
+        return self.get_var_itemsize(var_name)*len(self.get_value_ptr(var_name))
 
     #------------------------------------------------------------ 
     def get_value_at_indices(self, var_name: str, dest:np.ndarray, indices:np.ndarray) -> np.ndarray:

--- a/lstm/run_lstm_bmi.py
+++ b/lstm/run_lstm_bmi.py
@@ -29,7 +29,7 @@ print('Gathering input data')
 sample_data = Dataset(sample_data_file, 'r')
 
 # Now loop through the inputs, set the forcing values, and update the model
-print('Set values & update model for number of timesteps = 10')
+print('Set values & update model for number of timesteps = 100')
 for precip, temp in zip(list(sample_data['total_precipitation'][3].data),
                         list(sample_data['temperature'][3].data)):
 

--- a/ngen_files/data/lstm/rc_files/realization_config_lstm_CAMELS-test.json
+++ b/ngen_files/data/lstm/rc_files/realization_config_lstm_CAMELS-test.json
@@ -7,7 +7,7 @@
           "params": {
               "python_type": "lstm.bmi_lstm.bmi_LSTM",
               "model_type_name": "bmi_LSTM",
-              "init_config": "./extern/lstm_py/bmi_config_files/CAMELS-test/{{id}}.yml",
+              "init_config": "./data/lstm/yml_files/CAMELS-test/{{id}}.yml",
               "main_output_variable": "land_surface_water__runoff_volume_flux",
               "uses_forcing_file": false,
               "variables_names_map" : {

--- a/ngen_files/data/lstm/rc_files/realization_config_lstm_HUC01.json
+++ b/ngen_files/data/lstm/rc_files/realization_config_lstm_HUC01.json
@@ -5,9 +5,9 @@
         {
           "name": "bmi_python",
           "params": {
-              "python_type": "lstm.bmi_LSTM",
+              "python_type": "lstm.bmi_LSTM.bmi_LSTM",
               "model_type_name": "bmi_LSTM",
-              "init_config": "./extern/lstm_py/bmi_config_files/HUC01/{{id}}.yml",
+              "init_config": "./data/lstm/yml_files/HUC01/{{id}}.yml",
               "main_output_variable": "land_surface_water__runoff_volume_flux",
               "uses_forcing_file": false,
               "variables_names_map" : {

--- a/ngen_files/data/lstm/rc_files/realization_config_lstm_cat67a.json
+++ b/ngen_files/data/lstm/rc_files/realization_config_lstm_cat67a.json
@@ -5,9 +5,9 @@
         {
           "name": "bmi_python",
           "params": {
-              "python_type": "lstm.bmi_LSTM",
-              "model_type_name": "bmi_LSTM",
-              "init_config": "./extern/lstm_py/bmi_config_files/cat-67.yml",
+              "python_type": "lstm.bmi_LSTM.bmi_LSTM",
+              "model_type_name": "bmi_LSTM",  
+              "init_config": "./data/lstm/yml_files/HUC01/cat-67.yml",
               "main_output_variable": "land_surface_water__runoff_volume_flux",
               "uses_forcing_file": false,
               "variables_names_map" : {

--- a/ngen_files/data/lstm/rc_files/realization_config_lstm_cat67b.json
+++ b/ngen_files/data/lstm/rc_files/realization_config_lstm_cat67b.json
@@ -5,9 +5,9 @@
         {
           "name": "bmi_python",
           "params": {
-              "python_type": "lstm.bmi_LSTM",
+              "python_type": "lstm.bmi_LSTM.bmi_LSTM",
               "model_type_name": "bmi_LSTM",
-              "init_config": "./extern/lstm_py/bmi_config_files/cat-67.yml",
+              "init_config": "./data/lstm/yml_files/HUC01/cat-67.yml",
               "main_output_variable": "land_surface_water__runoff_volume_flux",
               "uses_forcing_file": false,
               "variables_names_map" : {


### PR DESCRIPTION
[Bmi_py_Adaptor.hpp](https://github.com/NOAA-OWP/ngen/blob/a223330d84cebf22846e7b254f856afb549165cf/include/realizations/catchment/Bmi_Py_Adapter.hpp#L221) `get_analogous_cxx_type` was throwing error at run time as `get_value_ptr()` now returns `np.array`. See merged PR #30 (and related closed issue #20) on getters and setters details. Required minor change to bmi func `get_var_type()`.  

bmi_lstm now builds/run in most recent ngen without error; output reasonable at glance. 

## Changes
- minor adjustment to bmi `get_var_type()`, from 
```
return type(self.get_value_ptr(long_var_name)).__name__
```
to
```
return self.get_value_ptr(long_var_name).dtype.name
```
- realization.json (s)
  - `python_type` needs to read `lstm.bmi_LSTM.bmi_LSTM`
  - fix pathing for `init_config` 


## Testing 
- `ngen` latest commit [a223330](https://github.com/NOAA-OWP/ngen/commit/a223330d84cebf22846e7b254f856afb549165cf) with and without `venv` active.  **Note: DOES NOT** require cmake build flag `-DLSTM_TORCH_LIB_ACTIVE`
- standalone, unit test, serialization src: `run_lstm_bmi.py`, `run_bmi_unit_test.py` & `lstm_serialization_test.py`
- notebooks: `lstm_serialization_test.ipynb` & `run_lstm_with_bmi.ipynb`
- py lib: `python -m lstm`


## TODO
Update docs specific to `ngen` and `venv`