### PR TITLE
Workflow & Python Version Update

### DIFF
--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # windows will fail(?)
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         activate-environment: bmi_lstm
         environment-file: ./environment.yml
-        python-version: ${{ matrix.python-version }}
+        #python-version: ${{ matrix.python-version }}
         # this may not be necessary? tbd..
         auto-activate-base: false
         

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # windows will fail(?)
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -32,10 +32,10 @@ jobs:
     - name: Checkout the commit
       uses: actions/checkout@v4
       
-    #- name: setup python # ${{ matrix.python-version }}
-    #  uses: actions/setup-python@v4
-    #  with:
-    #    python-version: ${{ matrix.python-version }}
+    - name: setup python # ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
         
     #- name: create conda env
     #  run: $CONDA/bin/conda env create -f environment.yml

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -30,7 +30,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout the commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       
     - name: setup python # ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Checkout the commit
       uses: actions/checkout@v4
       
-    - name: setup python # ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+    #- name: setup python # ${{ matrix.python-version }}
+    #  uses: actions/setup-python@v4
+    #  with:
+    #    python-version: ${{ matrix.python-version }}
         
     #- name: create conda env
     #  run: $CONDA/bin/conda env create -f environment.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         activate-environment: bmi_lstm
         environment-file: ./environment.yml
+        python-version: ${{ matrix.python-version }}
         # this may not be necessary? tbd..
         auto-activate-base: false
         

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -22,7 +22,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-lastest] # windows will fail(?)
+        os: [ubuntu-latest, macos-latest] # windows will fail(?)
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -41,7 +41,7 @@ jobs:
     #  run: $CONDA/bin/conda env create -f environment.yml
         
     - name: activate conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: bmi_lstm
         environment-file: ./environment.yml

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -22,7 +22,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # windows will fail(?)
+        os: [ubuntu-latest, macos-latest, windows-lastest] # windows will fail(?)
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # windows will fail(?)
-        python-version: [3.7, 3.8, 3.9] # 3.9(+) will fail
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_unit_standalone.yml
+++ b/.github/workflows/test_unit_standalone.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: setup python # ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - netcdf4
   - pandas
-  - python=3.7
+  - python
   - pytorch
   - ruamel.yaml
   - xarray=0.16.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - netcdf4
   - pandas
-  - python
+  - python=3.10
   - pytorch
   - ruamel.yaml
   - xarray=0.16.0


### PR DESCRIPTION
Updates python to v3.10 from v3.7.  Note that GH workflow tests for later versions as well.  Fixes issue #40. 

## Changes

- Conda env pins python v3.10
- Updates reusable actions to latest versions in workflow `yaml` (e.g. `uses: actions/checkout@v4`)

## Testing

1. Verified functionality of serialization work; namely [lstm_serialization_test.py](https://github.com/NOAA-OWP/lstm/blob/master/lstm/lstm_serialization_test.py)

## Requests
Recommend a `squash and merge` to cleanup redundant debug commits, etc. :)

