### PR TITLE
add @cache to freqent model info calls

### DIFF
--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -53,7 +53,7 @@ import collections
 import typing
 from dataclasses import dataclass
 from pathlib import Path
-from functools import cache
+from functools import lru_cache
 
 import numpy as np
 import numpy.typing as npt
@@ -478,47 +478,47 @@ class bmi_LSTM(BmiBase):
 
     def get_component_name(self) -> str:
         return "LSTM"
-        
-    @cache
+
+    @lru_cache(maxsize=None)
     def get_input_item_count(self) -> int:
         return len(self._dynamic_inputs)
-        
-    @cache
+
+    @lru_cache(maxsize=None)
     def get_output_item_count(self) -> int:
         return len(self._outputs)
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_input_var_names(self) -> tuple[str, ...]:  # type: ignore
         return tuple(self._dynamic_inputs.names())
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_output_var_names(self) -> tuple[str, ...]:  # type: ignore
         return tuple(self._outputs.names())
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_var_grid(self, name: str) -> int:
         # Note: all vars have grid 0 but check if its in names list first
         # raises KeyError on failure
         first_containing(name, self._outputs, self._dynamic_inputs)
         return 0
-        
-    @cache
+
+    @lru_cache(maxsize=None)
     def get_var_type(self, name: str) -> str:
         return self.get_value_ptr(name).dtype.name
-        
-    @cache
+
+    @lru_cache(maxsize=None)
     def get_var_units(self, name: str) -> str:
         return first_containing(name, self._outputs, self._dynamic_inputs).unit(name)
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_var_itemsize(self, name: str) -> int:
         return self.get_value_ptr(name).itemsize
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_var_nbytes(self, name: str) -> int:
         return self.get_var_itemsize(name) * len(self.get_value_ptr(name))
 
-    @cache
+    @lru_cache(maxsize=None)
     def get_var_location(self, name: str) -> str:
         # raises KeyError on failure
         first_containing(name, self._outputs, self._dynamic_inputs)

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -53,6 +53,7 @@ import collections
 import typing
 from dataclasses import dataclass
 from pathlib import Path
+from functools import cache
 
 import numpy as np
 import numpy.typing as npt
@@ -477,37 +478,47 @@ class bmi_LSTM(BmiBase):
 
     def get_component_name(self) -> str:
         return "LSTM"
-
+        
+    @cache
     def get_input_item_count(self) -> int:
         return len(self._dynamic_inputs)
-
+        
+    @cache
     def get_output_item_count(self) -> int:
         return len(self._outputs)
 
+    @cache
     def get_input_var_names(self) -> tuple[str, ...]:  # type: ignore
         return tuple(self._dynamic_inputs.names())
 
+    @cache
     def get_output_var_names(self) -> tuple[str, ...]:  # type: ignore
         return tuple(self._outputs.names())
 
+    @cache
     def get_var_grid(self, name: str) -> int:
         # Note: all vars have grid 0 but check if its in names list first
         # raises KeyError on failure
         first_containing(name, self._outputs, self._dynamic_inputs)
         return 0
-
+        
+    @cache
     def get_var_type(self, name: str) -> str:
         return self.get_value_ptr(name).dtype.name
-
+        
+    @cache
     def get_var_units(self, name: str) -> str:
         return first_containing(name, self._outputs, self._dynamic_inputs).unit(name)
 
+    @cache
     def get_var_itemsize(self, name: str) -> int:
         return self.get_value_ptr(name).itemsize
 
+    @cache
     def get_var_nbytes(self, name: str) -> int:
         return self.get_var_itemsize(name) * len(self.get_value_ptr(name))
 
+    @cache
     def get_var_location(self, name: str) -> str:
         # raises KeyError on failure
         first_containing(name, self._outputs, self._dynamic_inputs)


### PR DESCRIPTION
while testing out some bmi code I noticed that certain functions to fetch model info are called by ngen every timestep and sometimes multiple times in a row.
This PR adds @cache to some of these functions
<img width="785" height="2424" alt="image" src="https://github.com/user-attachments/assets/5d112926-6d9c-4db1-83a6-af6b8cb98943" />

when running gage-10154200 (55 catchments) for 1 year with 6 ensembles:
runtime dropped from `33.619 s ±  0.157 s` to `30.941 s ±  0.070 s`

when running a single model (ensemble of 1)
`14.093 s ±  0.110 s` ->  `11.436 s ±  0.175 s`

